### PR TITLE
feat: catch invalid sqrt arguments, mutate hamiltonian matrix directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hamilterm
+# Hamilterm
 
 Symbolically or numerically computes the rotational Hamiltonian for a given molecular term symbol.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ extend-select = [
 convention = "google"
 
 [tool.uv]
-required-version = "==0.8.5"
+required-version = "==0.8.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ readme = "README.md"
 authors = [
     { name = "nategphillips", email = "30729007+nategphillips@users.noreply.github.com" }
 ]
-requires-python = "==3.13.5"
+requires-python = "==3.13.7"
 dependencies = [
-    "numpy==2.3.1",
+    "numpy==2.3.2",
     "sympy==1.14.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ extend-select = [
 convention = "google"
 
 [tool.uv]
-required-version = "==0.8.11"
+required-version = "==0.8.24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "hamilterm"
+name = "Hamilterm"
 version = "0.1.0"
 description = "Symbolically and numerically computes the rotational Hamiltonian for a given molecular term symbol."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ extend-select = [
 convention = "google"
 
 [tool.uv]
-required-version = "==0.8.7"
+required-version = "==0.8.11"

--- a/src/hamilterm/elements.py
+++ b/src/hamilterm/elements.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import overload
-
 import numpy as np
 import sympy as sp
 from numpy.typing import NDArray
@@ -42,15 +40,7 @@ def j_squared_sym(j_qn: Symbol) -> Expr:
     return j_qn * (j_qn + 1)
 
 
-@overload
-def j_plus_num(j_qn: float, omega_qn_j: float) -> float: ...
-
-
-@overload
-def j_plus_num(j_qn: float, omega_qn_j: NDArray[np.float64]) -> NDArray[np.float64]: ...
-
-
-def j_plus_num(j_qn: float, omega_qn_j: float | NDArray[np.float64]) -> float | NDArray[np.float64]:
+def j_plus_num(j_qn: float, omega_qn_j: NDArray[np.float64]) -> NDArray[np.float64]:
     """Return the off-diagonal matrix element ⟨J, Ω - 1|J+|J, Ω⟩ = [J(J + 1) - Ω(Ω - 1)]^(1/2).
 
     Args:
@@ -60,24 +50,24 @@ def j_plus_num(j_qn: float, omega_qn_j: float | NDArray[np.float64]) -> float | 
     Returns:
         float: Matrix element [J(J + 1) - Ω(Ω - 1)]^(1/2)
     """
-    return np.sqrt(j_qn * (j_qn + 1) - omega_qn_j * (omega_qn_j - 1))
+    term = j_qn * (j_qn + 1) - omega_qn_j * (omega_qn_j - 1)
+
+    # NOTE: 25/08/12 - This check must be performed to avoid runtime errors in numpy. Unfortunately,
+    #       it slows down the computations by a noticeable margin. In the future, it might be worth
+    #       returning an error elsewhere if the values of J or S will result in a term that's less
+    #       than zero. The term.min() < 0.0 approach is noticeably faster than np.any(term < 0.0)
+    #       for some reason.
+    if term.min() < 0.0:
+        return np.zeros_like(omega_qn_j)
+
+    return np.sqrt(term)
 
 
 def j_plus_sym(j_qn: Symbol, omega_qn_j: Rational) -> Expr:
     return sp.sqrt(j_qn * (j_qn + 1) - omega_qn_j * (omega_qn_j - 1))
 
 
-@overload
-def j_minus_num(j_qn: float, omega_qn_j: float) -> float: ...
-
-
-@overload
-def j_minus_num(j_qn: float, omega_qn_j: NDArray[np.float64]) -> NDArray[np.float64]: ...
-
-
-def j_minus_num(
-    j_qn: float, omega_qn_j: float | NDArray[np.float64]
-) -> float | NDArray[np.float64]:
+def j_minus_num(j_qn: float, omega_qn_j: NDArray[np.float64]) -> NDArray[np.float64]:
     """Return the off-diagonal matrix element ⟨J, Ω + 1|J-|J, Ω⟩ = [J(J + 1) - Ω(Ω + 1)]^(1/2).
 
     Args:
@@ -87,7 +77,12 @@ def j_minus_num(
     Returns:
         float: Matrix element [J(J + 1) - Ω(Ω + 1)]^(1/2)
     """
-    return np.sqrt(j_qn * (j_qn + 1) - omega_qn_j * (omega_qn_j + 1))
+    term = j_qn * (j_qn + 1) - omega_qn_j * (omega_qn_j + 1)
+
+    if term.min() < 0.0:
+        return np.zeros_like(omega_qn_j)
+
+    return np.sqrt(term)
 
 
 def j_minus_sym(j_qn: Symbol, omega_qn_j: Rational) -> Expr:
@@ -110,15 +105,7 @@ def s_squared_sym(s_qn: Rational) -> Expr:
     return s_qn * (s_qn + 1)
 
 
-@overload
-def s_plus_num(s_qn: float, sigma_qn_j: float) -> float: ...
-
-
-@overload
-def s_plus_num(s_qn: float, sigma_qn_j: NDArray[np.float64]) -> NDArray[np.float64]: ...
-
-
-def s_plus_num(s_qn: float, sigma_qn_j: float | NDArray[np.float64]) -> float | NDArray[np.float64]:
+def s_plus_num(s_qn: float, sigma_qn_j: NDArray[np.float64]) -> NDArray[np.float64]:
     """Return the off-diagonal matrix element ⟨S, Σ + 1|S+|S, Σ⟩ = [S(S + 1) - Σ(Σ + 1)]^(1/2).
 
     Args:
@@ -128,24 +115,19 @@ def s_plus_num(s_qn: float, sigma_qn_j: float | NDArray[np.float64]) -> float | 
     Returns:
         float: Matrix element [S(S + 1) - Σ(Σ + 1)]^(1/2)
     """
-    return np.sqrt(s_qn * (s_qn + 1) - sigma_qn_j * (sigma_qn_j + 1))
+    term = s_qn * (s_qn + 1) - sigma_qn_j * (sigma_qn_j + 1)
+
+    if term.min() < 0.0:
+        return np.zeros_like(sigma_qn_j)
+
+    return np.sqrt(term)
 
 
 def s_plus_sym(s_qn: Rational, sigma_qn_j: Rational) -> Expr:
     return sp.sqrt(s_qn * (s_qn + 1) - sigma_qn_j * (sigma_qn_j + 1))
 
 
-@overload
-def s_minus_num(s_qn: float, sigma_qn_j: float) -> float: ...
-
-
-@overload
-def s_minus_num(s_qn: float, sigma_qn_j: NDArray[np.float64]) -> NDArray[np.float64]: ...
-
-
-def s_minus_num(
-    s_qn: float, sigma_qn_j: float | NDArray[np.float64]
-) -> float | NDArray[np.float64]:
+def s_minus_num(s_qn: float, sigma_qn_j: NDArray[np.float64]) -> NDArray[np.float64]:
     """Return the off-diagonal matrix element ⟨S, Σ - 1|S-|S, Σ⟩ = [S(S + 1) - Σ(Σ - 1)]^(1/2).
 
     Args:
@@ -155,7 +137,12 @@ def s_minus_num(
     Returns:
         float: Matrix element [S(S + 1) - Σ(Σ - 1)]^(1/2)
     """
-    return np.sqrt(s_qn * (s_qn + 1) - sigma_qn_j * (sigma_qn_j - 1))
+    term = s_qn * (s_qn + 1) - sigma_qn_j * (sigma_qn_j - 1)
+
+    if term.min() < 0.0:
+        return np.zeros_like(sigma_qn_j)
+
+    return np.sqrt(term)
 
 
 def s_minus_sym(s_qn: Rational, sigma_qn_j: Rational) -> Expr:
@@ -163,38 +150,45 @@ def s_minus_sym(s_qn: Rational, sigma_qn_j: Rational) -> Expr:
 
 
 def n_squared_num(
-    i: int, j: int, basis_fns: list[tuple[int, float, float]], s_qn: float, j_qn: float
-) -> float:
+    sigma_basis: NDArray[np.float64],
+    omega_basis: NDArray[np.float64],
+    s_qn: float,
+    j_qn: float,
+    dim: int,
+) -> NDArray[np.float64]:
     """Return matrix elements for the N^2 operator.
 
     N^2 = J^2 + S^2 - 2JzSz - (J+S- + J-S+).
 
     Args:
-        i (int): Index i (row) of the Hamiltonian matrix
-        j (int): Index j (col) of the Hamiltonian matrix
-        basis_fns (list[tuple[int, float, float]]): List of basis vectors |Λ, Σ; Ω>
         s_qn (float): Quantum number S
         j_qn (float): Quantum number J
 
     Returns:
         float | float: Matrix elements for J^2 + S^2 - 2JzSz - (J+S- + J-S+)
     """
-    _, sigma_qn_i, omega_qn_i = basis_fns[i]
-    _, sigma_qn_j, omega_qn_j = basis_fns[j]
+    sigma_i, sigma_j = utils.form_basis_matrices_num(sigma_basis)
+    omega_i, omega_j = utils.form_basis_matrices_num(omega_basis)
+
+    result: NDArray[np.float64] = np.zeros((dim, dim))
 
     # ⟨J, S, Ω, Σ|J^2 + S^2 - 2JzSz|J, S, Ω, Σ⟩ = J(J + 1) + S(S + 1) - 2ΩΣ
-    if i == j:
-        return j_squared_num(j_qn) + s_squared_num(s_qn) - 2 * omega_qn_j * sigma_qn_j
+    np.fill_diagonal(result, j_squared_num(j_qn) + s_squared_num(s_qn) - 2.0 * omega_j * sigma_j)
+
+    # Denote the areas in the array where Ω_i = Ω_j - 1 and Σ_i = Σ_j - 1
+    mask_minus: NDArray[np.bool] = (omega_i == omega_j - 1) & (sigma_i == sigma_j - 1)
+    # Denote the areas in the array where Ω_i = Ω_j + 1 and Σ_i = Σ_j + 1
+    mask_plus: NDArray[np.bool] = (omega_i == omega_j + 1) & (sigma_i == sigma_j + 1)
 
     # ⟨J, S, Ω - 1, Σ - 1|-(J+S-)|J, S, Ω, Σ⟩ = -([J(J + 1) - Ω(Ω - 1)][S(S + 1) - Σ(Σ - 1)])^(1/2)
-    if omega_qn_i == omega_qn_j - 1 and sigma_qn_i == sigma_qn_j - 1:
-        return -j_plus_num(j_qn, omega_qn_j) * s_minus_num(s_qn, sigma_qn_j)
-
+    term_minus: NDArray[np.float64] = -j_plus_num(j_qn, omega_j) * s_minus_num(s_qn, sigma_j)
     # ⟨J, S, Ω + 1, Σ + 1|-(J-S+)|J, S, Ω, Σ⟩ = -([J(J + 1) - Ω(Ω + 1)][S(S + 1) - Σ(Σ + 1)])^(1/2)
-    if omega_qn_i == omega_qn_j + 1 and sigma_qn_i == sigma_qn_j + 1:
-        return -j_minus_num(j_qn, omega_qn_j) * s_plus_num(s_qn, sigma_qn_j)
+    term_plus: NDArray[np.float64] = -j_minus_num(j_qn, omega_j) * s_plus_num(s_qn, sigma_j)
 
-    return 0.0
+    result[mask_minus] = term_minus[mask_minus]
+    result[mask_plus] = term_plus[mask_plus]
+
+    return result
 
 
 def n_squared_sym(

--- a/src/hamilterm/elements.py
+++ b/src/hamilterm/elements.py
@@ -277,6 +277,7 @@ def n_dot_s_num(
     omega_basis: NDArray[np.float64],
     s_qn: float,
     j_qn: float,
+    dim: int,
 ) -> NDArray[np.float64]:
     """Return matrix elements for the N·S operator.
 
@@ -292,8 +293,6 @@ def n_dot_s_num(
     Returns:
         float: Matrix elements for JzSz + 0.5(J+S- + J-S+) - S^2
     """
-    dim: int = sigma_basis.size
-
     sigma_i, sigma_j = utils.form_basis_matrices_num(sigma_basis)
     omega_i, omega_j = utils.form_basis_matrices_num(omega_basis)
 
@@ -345,7 +344,7 @@ def n_dot_s_sym(
 
 
 def sp2_plus_sm2_num(
-    lambda_basis: NDArray[np.int64], sigma_basis: NDArray[np.float64], s_qn: float
+    lambda_basis: NDArray[np.int64], sigma_basis: NDArray[np.float64], s_qn: float, dim: int
 ) -> NDArray[np.float64]:
     """Return matrix elements for the S+^2 + S-^2 operator.
 
@@ -358,8 +357,6 @@ def sp2_plus_sm2_num(
     Returns:
         float: Matrix elements for S+^2 + S-^2
     """
-    dim: int = lambda_basis.size
-
     lambda_i, lambda_j = utils.form_basis_matrices_num(lambda_basis)
     sigma_i, sigma_j = utils.form_basis_matrices_num(sigma_basis)
 
@@ -402,6 +399,7 @@ def jpsp_plus_jmsm_num(
     omega_basis: NDArray[np.float64],
     s_qn: float,
     j_qn: float,
+    dim: int,
 ) -> NDArray[np.float64]:
     """Return matrix elements for the J+S+ + J-S- operator.
 
@@ -415,8 +413,6 @@ def jpsp_plus_jmsm_num(
     Returns:
         float: Matrix elements for J+S+ + J-S-
     """
-    dim: int = lambda_basis.size
-
     lambda_i, lambda_j = utils.form_basis_matrices_num(lambda_basis)
     sigma_i, sigma_j = utils.form_basis_matrices_num(sigma_basis)
     omega_i, omega_j = utils.form_basis_matrices_num(omega_basis)
@@ -471,7 +467,7 @@ def jpsp_plus_jmsm_sym(
 
 
 def jp2_plus_jm2_num(
-    lambda_basis: NDArray[np.int64], omega_basis: NDArray[np.float64], j_qn: float
+    lambda_basis: NDArray[np.int64], omega_basis: NDArray[np.float64], j_qn: float, dim: int
 ) -> NDArray[np.float64]:
     """Return matrix elements for the J+^2 + J-^2 operator.
 
@@ -484,8 +480,6 @@ def jp2_plus_jm2_num(
     Returns:
         float: Matrix elements for J+^2 + J-^2
     """
-    dim: int = lambda_basis.size
-
     lambda_i, lambda_j = utils.form_basis_matrices_num(lambda_basis)
     omega_i, omega_j = utils.form_basis_matrices_num(omega_basis)
 

--- a/src/hamilterm/numerics.py
+++ b/src/hamilterm/numerics.py
@@ -64,7 +64,7 @@ class NumericComputation:
         lambda_basis, sigma_basis, omega_basis = utils.basis_vectors_num(basis_fns, dim)
 
         n_op_mats = utils.construct_n_operator_matrices_num(
-            basis_fns, s_qn, self.j_qn, self.max_n_index, dim
+            s_qn, self.j_qn, sigma_basis, omega_basis, self.max_n_index, dim
         )
 
         h_mat: NDArray[np.float64] = np.zeros((dim, dim))
@@ -158,7 +158,7 @@ def three_sigma(num: int) -> None:
         comp = NumericComputation(term_symbol, consts, j_qn, max_n_power=12, max_acomm_power=8)
         comp.hamiltonian
 
-    print(f"{num}\t3Σ Hamiltonians - vectorized: {timeit.timeit(bench, number=num)} s")
+    print(f"{num}\t3Σ Hamiltonians: {timeit.timeit(bench, number=num)} s")
 
 
 def two_pi(num: int) -> None:
@@ -179,7 +179,7 @@ def two_pi(num: int) -> None:
         comp = NumericComputation(term_symbol, consts, j_qn, max_n_power=12, max_acomm_power=8)
         comp.hamiltonian
 
-    print(f"{num}\t2Π Hamiltonians - vectorized: {timeit.timeit(bench, number=num)} s")
+    print(f"{num}\t2Π Hamiltonians: {timeit.timeit(bench, number=num)} s")
 
 
 def five_pi(num: int) -> None:
@@ -219,7 +219,7 @@ def five_pi(num: int) -> None:
         comp = NumericComputation(term_symbol, consts, j_qn, max_n_power=12, max_acomm_power=8)
         comp.hamiltonian
 
-    print(f"{num}\t5Π Hamiltonians - vectorized: {timeit.timeit(bench, number=num)} s")
+    print(f"{num}\t5Π Hamiltonians: {timeit.timeit(bench, number=num)} s")
 
 
 def main() -> None:

--- a/src/hamilterm/numerics.py
+++ b/src/hamilterm/numerics.py
@@ -58,11 +58,13 @@ class NumericComputation:
     def hamiltonian(self) -> NDArray[np.float64]:
         s_qn, lambda_qn = utils.parse_term_symbol_num(self.term_symbol)
         basis_fns: list[tuple[int, float, float]] = utils.generate_basis_fns_num(s_qn, lambda_qn)
-        lambda_basis, sigma_basis, omega_basis = utils.basis_vectors_num(basis_fns)
 
         dim: int = len(basis_fns)
+
+        lambda_basis, sigma_basis, omega_basis = utils.basis_vectors_num(basis_fns, dim)
+
         n_op_mats = utils.construct_n_operator_matrices_num(
-            basis_fns, s_qn, self.j_qn, self.max_n_index
+            basis_fns, s_qn, self.j_qn, self.max_n_index, dim
         )
 
         h_mat: NDArray[np.float64] = np.zeros((dim, dim))
@@ -77,10 +79,11 @@ class NumericComputation:
                 n_op_mats,
                 self.consts.spin_orbit,
                 self.max_acomm_index,
+                dim,
             )
         if options.INCLUDE_SS:
             h_mat += terms.spin_spin_num(
-                sigma_basis, s_qn, n_op_mats, self.consts.spin_spin, self.max_acomm_index
+                sigma_basis, s_qn, n_op_mats, self.consts.spin_spin, self.max_acomm_index, dim
             )
         if options.INCLUDE_SR:
             h_mat += terms.spin_rotation_num(
@@ -91,6 +94,7 @@ class NumericComputation:
                 n_op_mats,
                 self.consts.spin_rotation,
                 self.max_acomm_index,
+                dim,
             )
         if options.INCLUDE_LD:
             h_mat += terms.lambda_doubling_num(
@@ -102,6 +106,7 @@ class NumericComputation:
                 n_op_mats,
                 self.consts.lambda_doubling,
                 self.max_acomm_index,
+                dim,
             )
 
         return h_mat

--- a/src/hamilterm/numerics.py
+++ b/src/hamilterm/numerics.py
@@ -70,23 +70,24 @@ class NumericComputation:
         h_mat: NDArray[np.float64] = np.zeros((dim, dim))
 
         if options.INCLUDE_R:
-            h_mat += terms.rotational_num(n_op_mats, self.consts.rotational)
+            terms.rotational_num(h_mat, n_op_mats, self.consts.rotational)
         if options.INCLUDE_SO:
-            h_mat += terms.spin_orbit_num(
+            terms.spin_orbit_num(
+                h_mat,
                 lambda_basis,
                 sigma_basis,
                 s_qn,
                 n_op_mats,
                 self.consts.spin_orbit,
                 self.max_acomm_index,
-                dim,
             )
         if options.INCLUDE_SS:
-            h_mat += terms.spin_spin_num(
-                sigma_basis, s_qn, n_op_mats, self.consts.spin_spin, self.max_acomm_index, dim
+            terms.spin_spin_num(
+                h_mat, sigma_basis, s_qn, n_op_mats, self.consts.spin_spin, self.max_acomm_index
             )
         if options.INCLUDE_SR:
-            h_mat += terms.spin_rotation_num(
+            terms.spin_rotation_num(
+                h_mat,
                 sigma_basis,
                 omega_basis,
                 s_qn,
@@ -97,7 +98,8 @@ class NumericComputation:
                 dim,
             )
         if options.INCLUDE_LD:
-            h_mat += terms.lambda_doubling_num(
+            terms.lambda_doubling_num(
+                h_mat,
                 lambda_basis,
                 sigma_basis,
                 omega_basis,

--- a/src/hamilterm/symbolics.py
+++ b/src/hamilterm/symbolics.py
@@ -70,8 +70,9 @@ class SymbolicComputation:
         )
 
         dim: int = len(basis_fns)
+
         n_op_mats = utils.construct_n_operator_matrices_sym(
-            basis_fns, s_qn, self.j_qn, self.max_n_index
+            basis_fns, s_qn, self.j_qn, self.max_n_index, dim
         )
 
         h_mat: MutableDenseMatrix = sp.zeros(dim)

--- a/src/hamilterm/terms.py
+++ b/src/hamilterm/terms.py
@@ -72,6 +72,7 @@ def spin_orbit_num(
     n_op_mats: list[NDArray[np.float64]],
     so_consts: constants.SpinOrbitConstsNum,
     max_acomm_index: int,
+    dim: int,
 ) -> NDArray[np.float64]:
     """Return matrix elements for the spin-orbit Hamiltonian.
 
@@ -91,8 +92,6 @@ def spin_orbit_num(
         float: Matrix elements for A(LzSz) + A_D/2[N^2, LzSz]+ + A_H/2[N^4, LzSz]+
             + A_L/2[N^6, LzSz]+ + A_M/2[N^8, LzSz]+ + ηLzSz[Sz^2 - 1/5(3S^2 - 1)]
     """
-    dim: int = lambda_basis.size
-
     result: NDArray[np.float64] = np.zeros((dim, dim))
 
     # Spin-orbit coupling is only defined for states with Λ > 0 and S > 0. Since the Λ values in the
@@ -183,6 +182,7 @@ def spin_spin_num(
     n_op_mats: list[NDArray[np.float64]],
     ss_consts: constants.SpinSpinConstsNum,
     max_acomm_index: int,
+    dim: int,
 ) -> NDArray[np.float64]:
     """Return matrix elements for the spin-spin Hamiltonian.
 
@@ -202,8 +202,6 @@ def spin_spin_num(
         float: Matrix elements for 2λ/3(3Sz^2 - S^2) + λ_D/2[2/3(3Sz^2 - S^2), N^2]+
             + λ_H/2[2/3(3Sz^2 - S^2), N^4]+ + θ/12(35Sz^4 - 30S^2Sz^2 + 25Sz^2 - 6S^2 + 3S^4)
     """
-    dim: int = sigma_basis.size
-
     result: NDArray[np.float64] = np.zeros((dim, dim))
 
     # Spin-spin coupling is only defined for states with S > 1/2.
@@ -306,6 +304,7 @@ def spin_rotation_num(
     n_op_mats: list[NDArray[np.float64]],
     sr_consts: constants.SpinRotationConstsNum,
     max_acomm_index: int,
+    dim: int,
 ) -> NDArray[np.float64]:
     """Return matrix elements for the spin-rotation Hamiltonian.
 
@@ -326,8 +325,6 @@ def spin_rotation_num(
         float: Matrix elements for γ(N·S) + γ_D/2[N·S, N^2]+ + γ_H/2[N·S, N^4]+ + γ_L/2[N·S, N^6]+
             + -(70/3)^(1/2)γ_S * T_0^2{T^1(J), T^3(S)}
     """
-    dim: int = sigma_basis.size
-
     result: NDArray[np.float64] = np.zeros((dim, dim))
 
     # Spin-rotation coupling is only defined for states with S > 0.
@@ -335,7 +332,7 @@ def spin_rotation_num(
         return result
 
     # γ(N·S)
-    n_dot_s: NDArray[np.float64] = mel.n_dot_s_num(sigma_basis, omega_basis, s_qn, j_qn)
+    n_dot_s: NDArray[np.float64] = mel.n_dot_s_num(sigma_basis, omega_basis, s_qn, j_qn, dim)
     result += sr_consts.gamma * n_dot_s
 
     spin_rotation_cd_consts: NDArray[np.float64] = np.array(
@@ -458,6 +455,7 @@ def lambda_doubling_num(
     n_op_mats: list[NDArray[np.float64]],
     ld_consts: constants.LambdaDoublingConstsNum,
     max_acomm_index: int,
+    dim: int,
 ) -> NDArray[np.float64]:
     """Return matrix elements for the lambda doubling Hamiltonian.
 
@@ -482,8 +480,6 @@ def lambda_doubling_num(
             + 0.25(o_H + p_H + q_H)[S+^2 + S-^2, N^4]+ - 0.25(p_H + 2 * q_H)[J+S+ + J-S-, N^4]+ + q_H/4[J+^2 + J-^2, N^4]+
             + 0.25(o_L + p_L + q_L)[S+^2 + S-^2, N^6]+ - 0.25(p_L + 2 * q_L)[J+S+ + J-S-, N^6]+ + q_L/4[J+^2 + J-^2, N^6]+
     """
-    dim: int = lambda_basis.size
-
     result: NDArray[np.float64] = np.zeros((dim, dim))
 
     # Lambda doubling is only defined for Λ ± 2 transitions, i.e., Π states.
@@ -491,17 +487,17 @@ def lambda_doubling_num(
         return result
 
     # 0.5(o + p + q)(S+^2 + S-^2)
-    sp2_plus_sm2: NDArray[np.float64] = mel.sp2_plus_sm2_num(lambda_basis, sigma_basis, s_qn)
+    sp2_plus_sm2: NDArray[np.float64] = mel.sp2_plus_sm2_num(lambda_basis, sigma_basis, s_qn, dim)
     result += 0.5 * (ld_consts.o + ld_consts.p + ld_consts.q) * sp2_plus_sm2
 
     # -0.5(p + 2q)(J+S+ + J-S-)
     jpsp_plus_jmsm: NDArray[np.float64] = mel.jpsp_plus_jmsm_num(
-        lambda_basis, sigma_basis, omega_basis, s_qn, j_qn
+        lambda_basis, sigma_basis, omega_basis, s_qn, j_qn, dim
     )
     result += -0.5 * (ld_consts.p + 2 * ld_consts.q) * jpsp_plus_jmsm
 
     # q/2(J+^2 + J-^2)
-    jp2_plus_jm2: NDArray[np.float64] = mel.jp2_plus_jm2_num(lambda_basis, omega_basis, j_qn)
+    jp2_plus_jm2: NDArray[np.float64] = mel.jp2_plus_jm2_num(lambda_basis, omega_basis, j_qn, dim)
     result += 0.5 * ld_consts.q * jp2_plus_jm2
 
     lambda_doubling_cd_consts_opq: NDArray[np.float64] = np.array(

--- a/src/hamilterm/terms.py
+++ b/src/hamilterm/terms.py
@@ -25,8 +25,8 @@ from hamilterm import elements as mel
 
 
 def rotational_num(
-    n_op_mats: list[NDArray[np.float64]], r_consts: constants.RotationalConstsNum
-) -> NDArray[np.float64]:
+    ham, n_op_mats: list[NDArray[np.float64]], r_consts: constants.RotationalConstsNum
+) -> None:
     """Return matrix elements for the rotational Hamiltonian.
 
     H_r = BN^2 - DN^4 + HN^6 + LN^8 + MN^10 + PN^12
@@ -39,7 +39,7 @@ def rotational_num(
         float: Matrix elements for BN^2 - DN^4 + HN^6 + LN^8 + MN^10 + PN^12
     """
     # BN^2 - DN^4 + HN^6 + LN^8 + MN^10 + PN^12
-    return (
+    ham += (
         r_consts.B * n_op_mats[0]
         - r_consts.D * n_op_mats[1]
         + r_consts.H * n_op_mats[2]
@@ -66,14 +66,14 @@ def rotational_sym(
 
 
 def spin_orbit_num(
+    ham,
     lambda_basis: NDArray[np.int64],
     sigma_basis: NDArray[np.float64],
     s_qn: float,
     n_op_mats: list[NDArray[np.float64]],
     so_consts: constants.SpinOrbitConstsNum,
     max_acomm_index: int,
-    dim: int,
-) -> NDArray[np.float64]:
+) -> None:
     """Return matrix elements for the spin-orbit Hamiltonian.
 
     H_so = A(LzSz) + A_D/2[N^2, LzSz]+ + A_H/2[N^4, LzSz]+ + A_L/2[N^6, LzSz]+ + A_M/2[N^8, LzSz]+
@@ -92,16 +92,14 @@ def spin_orbit_num(
         float: Matrix elements for A(LzSz) + A_D/2[N^2, LzSz]+ + A_H/2[N^4, LzSz]+
             + A_L/2[N^6, LzSz]+ + A_M/2[N^8, LzSz]+ + ηLzSz[Sz^2 - 1/5(3S^2 - 1)]
     """
-    result: NDArray[np.float64] = np.zeros((dim, dim))
-
     # Spin-orbit coupling is only defined for states with Λ > 0 and S > 0. Since the Λ values in the
     # basis functions range from -Λ to +Λ, make sure to get the absolute value, |Λ|.
     if (np.abs(lambda_basis).max() == 0) or (s_qn <= 0.0):
-        return result
+        return
 
     # A(LzSz)
     lz_sz: NDArray[np.float64] = mel.lz_sz_num(lambda_basis, sigma_basis)
-    result += so_consts.A * lz_sz
+    ham += so_consts.A * lz_sz
 
     spin_orbit_cd_consts: NDArray[np.float64] = np.array(
         [
@@ -122,14 +120,12 @@ def spin_orbit_num(
             # ⟨i|A_x/2[N^{2n}, LzSz]+|j⟩ = A_x/2[⟨i|N^{2n}(LzSz)|j⟩ + ⟨i|(LzSz)N^{2n}|j⟩]
             #                            = A_x/2(∑_k⟨i|N^{2n}|k⟩⟨k|LzSz|j⟩ + ∑_k⟨i|LzSz|k⟩⟨k|N^{2n}|j⟩)
             #                            = A_x/2[(N^{2n})_{ik}(LzSz)_{kj} + (LzSz)_{ik}(N^{2n})_{kj}]
-            result += 0.5 * const * (n_op_mats[idx] @ lz_sz + lz_sz @ n_op_mats[idx])
+            ham += 0.5 * const * (n_op_mats[idx] @ lz_sz + lz_sz @ n_op_mats[idx])
 
     # ηLzSz[Sz^2 - 1/5(3S^2 - 1)] term only valid for states with S > 1.
     if s_qn > 1.0:
         # ⟨Λ, Σ|ηLzSz[Sz^2 - 1/5(3S^2 - 1)]|Λ, Σ⟩ = ηΛΣ[Σ^2 - 1/5(3S(S + 1) - 1)]
-        result += so_consts.eta * lz_sz * (sigma_basis**2 - 0.2 * (3 * mel.s_squared_num(s_qn) - 1))
-
-    return result
+        ham += so_consts.eta * lz_sz * (sigma_basis**2 - 0.2 * (3 * mel.s_squared_num(s_qn) - 1))
 
 
 def spin_orbit_sym(
@@ -177,13 +173,13 @@ def spin_orbit_sym(
 
 
 def spin_spin_num(
+    ham,
     sigma_basis: NDArray[np.float64],
     s_qn: float,
     n_op_mats: list[NDArray[np.float64]],
     ss_consts: constants.SpinSpinConstsNum,
     max_acomm_index: int,
-    dim: int,
-) -> NDArray[np.float64]:
+) -> None:
     """Return matrix elements for the spin-spin Hamiltonian.
 
     H_ss = 2λ/3(3Sz^2 - S^2) + λ_D/3[(3Sz^2 - S^2), N^2]+ + λ_H/3[(3Sz^2 - S^2), N^4]+
@@ -202,15 +198,13 @@ def spin_spin_num(
         float: Matrix elements for 2λ/3(3Sz^2 - S^2) + λ_D/2[2/3(3Sz^2 - S^2), N^2]+
             + λ_H/2[2/3(3Sz^2 - S^2), N^4]+ + θ/12(35Sz^4 - 30S^2Sz^2 + 25Sz^2 - 6S^2 + 3S^4)
     """
-    result: NDArray[np.float64] = np.zeros((dim, dim))
-
     # Spin-spin coupling is only defined for states with S > 1/2.
     if s_qn <= 0.5:
-        return result
+        return
 
     # 2λ/3(3Sz^2 - S^2)
     three_sz2_minus_s2: NDArray[np.float64] = mel.three_sz2_minus_s2_num(sigma_basis, s_qn)
-    result += (2.0 * ss_consts.lamda / 3.0) * three_sz2_minus_s2
+    ham += (2.0 * ss_consts.lamda / 3.0) * three_sz2_minus_s2
 
     spin_spin_cd_consts: NDArray[np.float64] = np.array([ss_consts.lamda_D, ss_consts.lamda_H])[
         :max_acomm_index
@@ -227,7 +221,7 @@ def spin_spin_num(
             #   = λ_x/3[⟨i|(3Sz^2 - S^2)N^{2n}|j⟩ + ⟨i|N^{2n}(3Sz^2 - S^2)|j⟩]
             #   = λ_x/3(∑_k⟨i|(3Sz^2 - S^2)|k⟩⟨k|N^{2n}|j⟩ + ∑_k⟨i|N^{2n}|k⟩⟨k|(3Sz^2 - S^2)|j⟩)
             #   = λ_x/3[(3Sz^2 - S^2)_{ik}(N^{2n})_{kj} + (N^{2n})_{ik}(3Sz^2 - S^2)_{kj}]
-            result += (const / 3.0) * (
+            ham += (const / 3.0) * (
                 three_sz2_minus_s2 @ n_op_mats[idx] + n_op_mats[idx] @ three_sz2_minus_s2
             )
 
@@ -235,7 +229,7 @@ def spin_spin_num(
     if s_qn > 1.5:
         # ⟨S, Σ|θ/12(35Sz^4 - 30S^2Sz^2 + 25Sz^2 - 6S^2 + 3S^4)|S, Σ⟩
         #   = θ/12(35Σ^4 - 30S(S + 1)Σ^2 + 25Σ^2 - 6S(S + 1) + 3[S(S + 1)]^2)
-        result += np.diag(
+        ham += np.diag(
             (ss_consts.theta / 12.0)
             * (
                 35.0 * sigma_basis**4
@@ -245,8 +239,6 @@ def spin_spin_num(
                 + 3.0 * mel.s_squared_num(s_qn) ** 2
             )
         )
-
-    return result
 
 
 def spin_spin_sym(
@@ -297,6 +289,7 @@ def spin_spin_sym(
 
 
 def spin_rotation_num(
+    ham,
     sigma_basis: NDArray[np.float64],
     omega_basis: NDArray[np.float64],
     s_qn: float,
@@ -305,7 +298,7 @@ def spin_rotation_num(
     sr_consts: constants.SpinRotationConstsNum,
     max_acomm_index: int,
     dim: int,
-) -> NDArray[np.float64]:
+) -> None:
     """Return matrix elements for the spin-rotation Hamiltonian.
 
     H_sr = γ(N·S) + γ_D/2[N·S, N^2]+ + γ_H/2[N·S, N^4]+ + γ_L/2[N·S, N^6]+
@@ -325,15 +318,13 @@ def spin_rotation_num(
         float: Matrix elements for γ(N·S) + γ_D/2[N·S, N^2]+ + γ_H/2[N·S, N^4]+ + γ_L/2[N·S, N^6]+
             + -(70/3)^(1/2)γ_S * T_0^2{T^1(J), T^3(S)}
     """
-    result: NDArray[np.float64] = np.zeros((dim, dim))
-
     # Spin-rotation coupling is only defined for states with S > 0.
     if s_qn <= 0.0:
-        return result
+        return
 
     # γ(N·S)
     n_dot_s: NDArray[np.float64] = mel.n_dot_s_num(sigma_basis, omega_basis, s_qn, j_qn, dim)
-    result += sr_consts.gamma * n_dot_s
+    ham += sr_consts.gamma * n_dot_s
 
     spin_rotation_cd_consts: NDArray[np.float64] = np.array(
         [sr_consts.gamma_D, sr_consts.gamma_H, sr_consts.gamma_L]
@@ -349,7 +340,7 @@ def spin_rotation_num(
             # ⟨i|γ_x/2[N·S, N^{2n}]+|j⟩ = γ_x/2[⟨i|(N·S)N^{2n}|j⟩ + ⟨i|N^{2n}(N·S)|j⟩]
             #                           = γ_x/2(∑_k⟨i|N·S|k⟩⟨k|N^{2n}|j⟩ + ∑_k⟨i|N^{2n}|k⟩⟨k|N·S|j⟩)
             #                           = γ_x/2[(N·S)_{ik}(N^{2n})_{kj} + (N^{2n})_{ik}(N·S)_{kj}]
-            result += 0.5 * const * (n_dot_s @ n_op_mats[idx] + n_op_mats[idx] @ n_dot_s)
+            ham += 0.5 * const * (n_dot_s @ n_op_mats[idx] + n_op_mats[idx] @ n_dot_s)
 
     # -(70/3)^(1/2)γ_S * T_0^2{T^1(J), T^3(S)} term only valid for states with S > 1.
     if s_qn > 1.0:
@@ -383,10 +374,8 @@ def spin_rotation_num(
             * mel.s_plus_num(s_qn, sigma_j)
         )
 
-        result[mask_minus] += term_minus[mask_minus]
-        result[mask_plus] += term_plus[mask_plus]
-
-    return result
+        ham[mask_minus] += term_minus[mask_minus]
+        ham[mask_plus] += term_plus[mask_plus]
 
 
 def spin_rotation_sym(
@@ -447,6 +436,7 @@ def spin_rotation_sym(
 
 
 def lambda_doubling_num(
+    ham,
     lambda_basis: NDArray[np.int64],
     sigma_basis: NDArray[np.float64],
     omega_basis: NDArray[np.float64],
@@ -456,7 +446,7 @@ def lambda_doubling_num(
     ld_consts: constants.LambdaDoublingConstsNum,
     max_acomm_index: int,
     dim: int,
-) -> NDArray[np.float64]:
+) -> None:
     """Return matrix elements for the lambda doubling Hamiltonian.
 
     H_ld = 0.5(o + p + q)(S+^2 + S-^2) - 0.5(p + 2q)(J+S+ + J-S-) + q/2(J+^2 + J-^2)
@@ -480,25 +470,23 @@ def lambda_doubling_num(
             + 0.25(o_H + p_H + q_H)[S+^2 + S-^2, N^4]+ - 0.25(p_H + 2 * q_H)[J+S+ + J-S-, N^4]+ + q_H/4[J+^2 + J-^2, N^4]+
             + 0.25(o_L + p_L + q_L)[S+^2 + S-^2, N^6]+ - 0.25(p_L + 2 * q_L)[J+S+ + J-S-, N^6]+ + q_L/4[J+^2 + J-^2, N^6]+
     """
-    result: NDArray[np.float64] = np.zeros((dim, dim))
-
     # Lambda doubling is only defined for Λ ± 2 transitions, i.e., Π states.
     if lambda_basis.max() != 1.0:
-        return result
+        return
 
     # 0.5(o + p + q)(S+^2 + S-^2)
     sp2_plus_sm2: NDArray[np.float64] = mel.sp2_plus_sm2_num(lambda_basis, sigma_basis, s_qn, dim)
-    result += 0.5 * (ld_consts.o + ld_consts.p + ld_consts.q) * sp2_plus_sm2
+    ham += 0.5 * (ld_consts.o + ld_consts.p + ld_consts.q) * sp2_plus_sm2
 
     # -0.5(p + 2q)(J+S+ + J-S-)
     jpsp_plus_jmsm: NDArray[np.float64] = mel.jpsp_plus_jmsm_num(
         lambda_basis, sigma_basis, omega_basis, s_qn, j_qn, dim
     )
-    result += -0.5 * (ld_consts.p + 2 * ld_consts.q) * jpsp_plus_jmsm
+    ham += -0.5 * (ld_consts.p + 2 * ld_consts.q) * jpsp_plus_jmsm
 
     # q/2(J+^2 + J-^2)
     jp2_plus_jm2: NDArray[np.float64] = mel.jp2_plus_jm2_num(lambda_basis, omega_basis, j_qn, dim)
-    result += 0.5 * ld_consts.q * jp2_plus_jm2
+    ham += 0.5 * ld_consts.q * jp2_plus_jm2
 
     lambda_doubling_cd_consts_opq: NDArray[np.float64] = np.array(
         [
@@ -540,14 +528,14 @@ def lambda_doubling_num(
             #   = 0.25(o_x + p_x + q_x)[⟨i|(S+^2 + S-^2)N^{2n}|j⟩ + ⟨i|N^{2n}(S+^2 + S-^2)|j⟩]
             #   = 0.25(o_x + p_x + q_x)(∑_k⟨i|S+^2 + S-^2|k⟩⟨k|N^{2n}|j⟩ + ∑_k⟨i|N^{2n}|k⟩⟨k|S+^2 + S-^2|j⟩)
             #   = 0.25(o_x + p_x + q_x)[(S+^2 + S-^2)_{ik}(N^{2n})_{kj} + (N^{2n})_{ik}(S+^2 + S-^2)_{kj}]
-            result += 0.25 * const * (sp2_plus_sm2 @ n_op_mats[idx] + n_op_mats[idx] @ sp2_plus_sm2)
+            ham += 0.25 * const * (sp2_plus_sm2 @ n_op_mats[idx] + n_op_mats[idx] @ sp2_plus_sm2)
 
         for idx, const in enumerate(lambda_doubling_cd_consts_pq):
             # ⟨i|[-0.25(p_x + 2 * q_x)(J+S+ + J-S-), N^{2n}]+|j⟩
             #   = -0.25(p_x + 2 * q_x)[⟨i|(J+S+ + J-S-)N^{2n}|j⟩ + ⟨i|N^{2n}(J+S+ + J-S-)|j⟩]
             #   = -0.25(p_x + 2 * q_x)(∑_k⟨i|J+S+ + J-S-|k⟩⟨k|N^{2n}|j⟩ + ∑_k⟨i|N^{2n}|k⟩⟨k|J+S+ + J-S-|j⟩)
             #   = -0.25(p_x + 2 * q_x)[(J+S+ + J-S-)_{ik}(N^{2n})_{kj} + (N^{2n})_{ik}(J+S+ + J-S-)_{kj}]
-            result += (
+            ham += (
                 -0.25 * const * (jpsp_plus_jmsm @ n_op_mats[idx] + n_op_mats[idx] @ jpsp_plus_jmsm)
             )
 
@@ -556,9 +544,7 @@ def lambda_doubling_num(
             #   = 0.25 * q_x[⟨i|(J+^2 + J-^2)N^{2n}|j⟩ + ⟨i|N^{2n}(J+^2 + J-^2)|j⟩]
             #   = 0.25 * q_x(∑_k⟨i|J+^2 + J-^2|k⟩⟨k|N^{2n}|j⟩ + ∑_k⟨i|N^{2n}|k⟩⟨k|J+^2 + J-^2|j⟩)
             #   = 0.25 * q_x[(J+^2 + J-^2)_{ik}(N^{2n})_{kj} + (N^{2n})_{ik}(J+^2 + J-^2)_{kj}]
-            result += 0.25 * const * (jp2_plus_jm2 @ n_op_mats[idx] + n_op_mats[idx] @ jp2_plus_jm2)
-
-    return result
+            ham += 0.25 * const * (jp2_plus_jm2 @ n_op_mats[idx] + n_op_mats[idx] @ jp2_plus_jm2)
 
 
 def lambda_doubling_sym(

--- a/src/hamilterm/utils.py
+++ b/src/hamilterm/utils.py
@@ -49,9 +49,10 @@ def safe_rational(num: int, denom: int) -> Rational:
 
 
 def construct_n_operator_matrices_num(
-    basis_fns: list[tuple[int, float, float]],
     s_qn: float,
     j_qn: float,
+    sigma_basis: NDArray[np.float64],
+    omega_basis: NDArray[np.float64],
     max_n_index: int,
     dim: int,
 ) -> list[NDArray[np.float64]]:
@@ -73,9 +74,7 @@ def construct_n_operator_matrices_num(
     n_op_mats: list[NDArray[np.float64]] = [np.zeros((dim, dim)) for _ in range(6)]
 
     # Form the N^2 matrix using the matrix elements above.
-    for i in range(dim):
-        for j in range(dim):
-            n_op_mats[0][i, j] = mel.n_squared_num(i, j, basis_fns, s_qn, j_qn)
+    n_op_mats[0] = mel.n_squared_num(sigma_basis, omega_basis, s_qn, j_qn, dim)
 
     # The following N^{2k} matrices, where k > 1, are formed using matrix multiplication.
     for i in range(1, max_n_index):

--- a/src/hamilterm/utils.py
+++ b/src/hamilterm/utils.py
@@ -53,6 +53,7 @@ def construct_n_operator_matrices_num(
     s_qn: float,
     j_qn: float,
     max_n_index: int,
+    dim: int,
 ) -> list[NDArray[np.float64]]:
     """Construct the N operator matrices, where N is the total angular momentum w/o any spin.
 
@@ -65,9 +66,6 @@ def construct_n_operator_matrices_num(
     Returns:
         list[NDArray[np.float64]]: N operator matrices
     """
-    # The number of basis functions determine the size of the N operator matrix.
-    dim: int = len(basis_fns)
-
     # Each N^{2k} operator, where k is an integer, will have its own operator matrix. This notation
     # implies the N^2 operator occupies index 0, N^4 occupies index 1, etc. Always initialize the
     # operator matrices up to N^12 - if MAX_N_POWER is less than 12, the unused matrices will have
@@ -91,9 +89,8 @@ def construct_n_operator_matrices_sym(
     s_qn: Rational,
     j_qn: Symbol,
     max_n_index: int,
+    dim: int,
 ) -> list[MutableDenseMatrix]:
-    dim: int = len(basis_fns)
-
     n_op_mats: list[MutableDenseMatrix] = [sp.zeros(dim) for _ in range(6)]
 
     for i in range(dim):
@@ -174,7 +171,7 @@ def generate_basis_fns_sym(
 
 
 def basis_vectors_num(
-    basis_fns: list[tuple[int, float, float]],
+    basis_fns: list[tuple[int, float, float]], dim: int
 ) -> tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.float64]]:
     """Construct basis arrays of Λ, Σ, and Ω for use with vectorized functions.
 
@@ -185,7 +182,6 @@ def basis_vectors_num(
         tuple[NDArray[np.int64], NDArray[np.float64], NDArray[np.float64]]: Basis vectors for Λ, Σ,
             and Ω
     """
-    dim: int = len(basis_fns)
     lambda_basis: NDArray[np.int64] = np.empty(dim, dtype=np.int64)
     sigma_basis: NDArray[np.float64] = np.empty(dim, dtype=np.float64)
     omega_basis: NDArray[np.float64] = np.empty(dim, dtype=np.float64)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 1
-requires-python = "==3.13.5"
+revision = 3
+requires-python = "==3.13.7"
 
 [[package]]
 name = "hamilterm"
@@ -13,7 +13,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numpy", specifier = "==2.3.1" },
+    { name = "numpy", specifier = "==2.3.2" },
     { name = "sympy", specifier = "==1.14.0" },
 ]
 
@@ -21,39 +21,39 @@ requires-dist = [
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
 name = "numpy"
-version = "2.3.1"
+version = "2.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/19/d7c972dfe90a353dbd3efbbe1d14a5951de80c99c9dc1b93cd998d51dc0f/numpy-2.3.1.tar.gz", hash = "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b", size = 20390372 }
+sdist = { url = "https://files.pythonhosted.org/packages/37/7d/3fec4199c5ffb892bed55cff901e4f39a58c81df9c44c280499e92cad264/numpy-2.3.2.tar.gz", hash = "sha256:e0486a11ec30cdecb53f184d496d1c6a20786c81e55e41640270130056f8ee48", size = 20489306, upload-time = "2025-07-24T21:32:07.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/bd/35ad97006d8abff8631293f8ea6adf07b0108ce6fec68da3c3fcca1197f2/numpy-2.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25a1992b0a3fdcdaec9f552ef10d8103186f5397ab45e2d25f8ac51b1a6b97e8", size = 20889381 },
-    { url = "https://files.pythonhosted.org/packages/f1/4f/df5923874d8095b6062495b39729178eef4a922119cee32a12ee1bd4664c/numpy-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7dea630156d39b02a63c18f508f85010230409db5b2927ba59c8ba4ab3e8272e", size = 14152726 },
-    { url = "https://files.pythonhosted.org/packages/8c/0f/a1f269b125806212a876f7efb049b06c6f8772cf0121139f97774cd95626/numpy-2.3.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bada6058dd886061f10ea15f230ccf7dfff40572e99fef440a4a857c8728c9c0", size = 5105145 },
-    { url = "https://files.pythonhosted.org/packages/6d/63/a7f7fd5f375b0361682f6ffbf686787e82b7bbd561268e4f30afad2bb3c0/numpy-2.3.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:a894f3816eb17b29e4783e5873f92faf55b710c2519e5c351767c51f79d8526d", size = 6639409 },
-    { url = "https://files.pythonhosted.org/packages/bf/0d/1854a4121af895aab383f4aa233748f1df4671ef331d898e32426756a8a6/numpy-2.3.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:18703df6c4a4fee55fd3d6e5a253d01c5d33a295409b03fda0c86b3ca2ff41a1", size = 14257630 },
-    { url = "https://files.pythonhosted.org/packages/50/30/af1b277b443f2fb08acf1c55ce9d68ee540043f158630d62cef012750f9f/numpy-2.3.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5902660491bd7a48b2ec16c23ccb9124b8abfd9583c5fdfa123fe6b421e03de1", size = 16627546 },
-    { url = "https://files.pythonhosted.org/packages/6e/ec/3b68220c277e463095342d254c61be8144c31208db18d3fd8ef02712bcd6/numpy-2.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:36890eb9e9d2081137bd78d29050ba63b8dab95dff7912eadf1185e80074b2a0", size = 15562538 },
-    { url = "https://files.pythonhosted.org/packages/77/2b/4014f2bcc4404484021c74d4c5ee8eb3de7e3f7ac75f06672f8dcf85140a/numpy-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a780033466159c2270531e2b8ac063704592a0bc62ec4a1b991c7c40705eb0e8", size = 18360327 },
-    { url = "https://files.pythonhosted.org/packages/40/8d/2ddd6c9b30fcf920837b8672f6c65590c7d92e43084c25fc65edc22e93ca/numpy-2.3.1-cp313-cp313-win32.whl", hash = "sha256:39bff12c076812595c3a306f22bfe49919c5513aa1e0e70fac756a0be7c2a2b8", size = 6312330 },
-    { url = "https://files.pythonhosted.org/packages/dd/c8/beaba449925988d415efccb45bf977ff8327a02f655090627318f6398c7b/numpy-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d5ee6eec45f08ce507a6570e06f2f879b374a552087a4179ea7838edbcbfa42", size = 12731565 },
-    { url = "https://files.pythonhosted.org/packages/0b/c3/5c0c575d7ec78c1126998071f58facfc124006635da75b090805e642c62e/numpy-2.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c4d9e0a8368db90f93bd192bfa771ace63137c3488d198ee21dfb8e7771916e", size = 10190262 },
-    { url = "https://files.pythonhosted.org/packages/ea/19/a029cd335cf72f79d2644dcfc22d90f09caa86265cbbde3b5702ccef6890/numpy-2.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b0b5397374f32ec0649dd98c652a1798192042e715df918c20672c62fb52d4b8", size = 20987593 },
-    { url = "https://files.pythonhosted.org/packages/25/91/8ea8894406209107d9ce19b66314194675d31761fe2cb3c84fe2eeae2f37/numpy-2.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c5bdf2015ccfcee8253fb8be695516ac4457c743473a43290fd36eba6a1777eb", size = 14300523 },
-    { url = "https://files.pythonhosted.org/packages/a6/7f/06187b0066eefc9e7ce77d5f2ddb4e314a55220ad62dd0bfc9f2c44bac14/numpy-2.3.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d70f20df7f08b90a2062c1f07737dd340adccf2068d0f1b9b3d56e2038979fee", size = 5227993 },
-    { url = "https://files.pythonhosted.org/packages/e8/ec/a926c293c605fa75e9cfb09f1e4840098ed46d2edaa6e2152ee35dc01ed3/numpy-2.3.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:2fb86b7e58f9ac50e1e9dd1290154107e47d1eef23a0ae9145ded06ea606f992", size = 6736652 },
-    { url = "https://files.pythonhosted.org/packages/e3/62/d68e52fb6fde5586650d4c0ce0b05ff3a48ad4df4ffd1b8866479d1d671d/numpy-2.3.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:23ab05b2d241f76cb883ce8b9a93a680752fbfcbd51c50eff0b88b979e471d8c", size = 14331561 },
-    { url = "https://files.pythonhosted.org/packages/fc/ec/b74d3f2430960044bdad6900d9f5edc2dc0fb8bf5a0be0f65287bf2cbe27/numpy-2.3.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ce2ce9e5de4703a673e705183f64fd5da5bf36e7beddcb63a25ee2286e71ca48", size = 16693349 },
-    { url = "https://files.pythonhosted.org/packages/0d/15/def96774b9d7eb198ddadfcbd20281b20ebb510580419197e225f5c55c3e/numpy-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c4913079974eeb5c16ccfd2b1f09354b8fed7e0d6f2cab933104a09a6419b1ee", size = 15642053 },
-    { url = "https://files.pythonhosted.org/packages/2b/57/c3203974762a759540c6ae71d0ea2341c1fa41d84e4971a8e76d7141678a/numpy-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:010ce9b4f00d5c036053ca684c77441f2f2c934fd23bee058b4d6f196efd8280", size = 18434184 },
-    { url = "https://files.pythonhosted.org/packages/22/8a/ccdf201457ed8ac6245187850aff4ca56a79edbea4829f4e9f14d46fa9a5/numpy-2.3.1-cp313-cp313t-win32.whl", hash = "sha256:6269b9edfe32912584ec496d91b00b6d34282ca1d07eb10e82dfc780907d6c2e", size = 6440678 },
-    { url = "https://files.pythonhosted.org/packages/f1/7e/7f431d8bd8eb7e03d79294aed238b1b0b174b3148570d03a8a8a8f6a0da9/numpy-2.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2a809637460e88a113e186e87f228d74ae2852a2e0c44de275263376f17b5bdc", size = 12870697 },
-    { url = "https://files.pythonhosted.org/packages/d4/ca/af82bf0fad4c3e573c6930ed743b5308492ff19917c7caaf2f9b6f9e2e98/numpy-2.3.1-cp313-cp313t-win_arm64.whl", hash = "sha256:eccb9a159db9aed60800187bc47a6d3451553f0e1b08b068d8b277ddfbb9b244", size = 10260376 },
+    { url = "https://files.pythonhosted.org/packages/1c/c0/c6bb172c916b00700ed3bf71cb56175fd1f7dbecebf8353545d0b5519f6c/numpy-2.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c8d9727f5316a256425892b043736d63e89ed15bbfe6556c5ff4d9d4448ff3b3", size = 20949074, upload-time = "2025-07-24T20:43:07.813Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4e/c116466d22acaf4573e58421c956c6076dc526e24a6be0903219775d862e/numpy-2.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:efc81393f25f14d11c9d161e46e6ee348637c0a1e8a54bf9dedc472a3fae993b", size = 14177311, upload-time = "2025-07-24T20:43:29.335Z" },
+    { url = "https://files.pythonhosted.org/packages/78/45/d4698c182895af189c463fc91d70805d455a227261d950e4e0f1310c2550/numpy-2.3.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:dd937f088a2df683cbb79dda9a772b62a3e5a8a7e76690612c2737f38c6ef1b6", size = 5106022, upload-time = "2025-07-24T20:43:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/3e6880fef4420179309dba72a8c11f6166c431cf6dee54c577af8906f914/numpy-2.3.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:11e58218c0c46c80509186e460d79fbdc9ca1eb8d8aee39d8f2dc768eb781089", size = 6640135, upload-time = "2025-07-24T20:43:49.28Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fa/87ff7f25b3c4ce9085a62554460b7db686fef1e0207e8977795c7b7d7ba1/numpy-2.3.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5ad4ebcb683a1f99f4f392cc522ee20a18b2bb12a2c1c42c3d48d5a1adc9d3d2", size = 14278147, upload-time = "2025-07-24T20:44:10.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/0f/571b2c7a3833ae419fe69ff7b479a78d313581785203cc70a8db90121b9a/numpy-2.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:938065908d1d869c7d75d8ec45f735a034771c6ea07088867f713d1cd3bbbe4f", size = 16635989, upload-time = "2025-07-24T20:44:34.88Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5a/84ae8dca9c9a4c592fe11340b36a86ffa9fd3e40513198daf8a97839345c/numpy-2.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:66459dccc65d8ec98cc7df61307b64bf9e08101f9598755d42d8ae65d9a7a6ee", size = 16053052, upload-time = "2025-07-24T20:44:58.872Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7c/e5725d99a9133b9813fcf148d3f858df98511686e853169dbaf63aec6097/numpy-2.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a7af9ed2aa9ec5950daf05bb11abc4076a108bd3c7db9aa7251d5f107079b6a6", size = 18577955, upload-time = "2025-07-24T20:45:26.714Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl", hash = "sha256:906a30249315f9c8e17b085cc5f87d3f369b35fedd0051d4a84686967bdbbd0b", size = 6311843, upload-time = "2025-07-24T20:49:24.444Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/6f/a428fd1cb7ed39b4280d057720fed5121b0d7754fd2a9768640160f5517b/numpy-2.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:c63d95dc9d67b676e9108fe0d2182987ccb0f11933c1e8959f42fa0da8d4fa56", size = 12782876, upload-time = "2025-07-24T20:49:43.227Z" },
+    { url = "https://files.pythonhosted.org/packages/65/85/4ea455c9040a12595fb6c43f2c217257c7b52dd0ba332c6a6c1d28b289fe/numpy-2.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:b05a89f2fb84d21235f93de47129dd4f11c16f64c87c33f5e284e6a3a54e43f2", size = 10192786, upload-time = "2025-07-24T20:49:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/80/23/8278f40282d10c3f258ec3ff1b103d4994bcad78b0cba9208317f6bb73da/numpy-2.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4e6ecfeddfa83b02318f4d84acf15fbdbf9ded18e46989a15a8b6995dfbf85ab", size = 21047395, upload-time = "2025-07-24T20:45:58.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/2d/624f2ce4a5df52628b4ccd16a4f9437b37c35f4f8a50d00e962aae6efd7a/numpy-2.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:508b0eada3eded10a3b55725b40806a4b855961040180028f52580c4729916a2", size = 14300374, upload-time = "2025-07-24T20:46:20.207Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/62/ff1e512cdbb829b80a6bd08318a58698867bca0ca2499d101b4af063ee97/numpy-2.3.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:754d6755d9a7588bdc6ac47dc4ee97867271b17cee39cb87aef079574366db0a", size = 5228864, upload-time = "2025-07-24T20:46:30.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8e/74bc18078fff03192d4032cfa99d5a5ca937807136d6f5790ce07ca53515/numpy-2.3.2-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a9f66e7d2b2d7712410d3bc5684149040ef5f19856f20277cd17ea83e5006286", size = 6737533, upload-time = "2025-07-24T20:46:46.111Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ea/0731efe2c9073ccca5698ef6a8c3667c4cf4eea53fcdcd0b50140aba03bc/numpy-2.3.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6ea4e5a65d5a90c7d286ddff2b87f3f4ad61faa3db8dabe936b34c2275b6f8", size = 14352007, upload-time = "2025-07-24T20:47:07.1Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/90/36be0865f16dfed20f4bc7f75235b963d5939707d4b591f086777412ff7b/numpy-2.3.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3ef07ec8cbc8fc9e369c8dcd52019510c12da4de81367d8b20bc692aa07573a", size = 16701914, upload-time = "2025-07-24T20:47:32.459Z" },
+    { url = "https://files.pythonhosted.org/packages/94/30/06cd055e24cb6c38e5989a9e747042b4e723535758e6153f11afea88c01b/numpy-2.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:27c9f90e7481275c7800dc9c24b7cc40ace3fdb970ae4d21eaff983a32f70c91", size = 16132708, upload-time = "2025-07-24T20:47:58.129Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/14/ecede608ea73e58267fd7cb78f42341b3b37ba576e778a1a06baffbe585c/numpy-2.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:07b62978075b67eee4065b166d000d457c82a1efe726cce608b9db9dd66a73a5", size = 18651678, upload-time = "2025-07-24T20:48:25.402Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f3/2fe6066b8d07c3685509bc24d56386534c008b462a488b7f503ba82b8923/numpy-2.3.2-cp313-cp313t-win32.whl", hash = "sha256:c771cfac34a4f2c0de8e8c97312d07d64fd8f8ed45bc9f5726a7e947270152b5", size = 6441832, upload-time = "2025-07-24T20:48:37.181Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ba/0937d66d05204d8f28630c9c60bc3eda68824abde4cf756c4d6aad03b0c6/numpy-2.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:72dbebb2dcc8305c431b2836bcc66af967df91be793d63a24e3d9b741374c450", size = 12927049, upload-time = "2025-07-24T20:48:56.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/ed/13542dd59c104d5e654dfa2ac282c199ba64846a74c2c4bcdbc3a0f75df1/numpy-2.3.2-cp313-cp313t-win_arm64.whl", hash = "sha256:72c6df2267e926a6d5286b0a6d556ebe49eae261062059317837fda12ddf0c1a", size = 10262935, upload-time = "2025-07-24T20:49:13.136Z" },
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mpmath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921 }
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353 },
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]


### PR DESCRIPTION
Changes:
- In matrix elements where the argument of the square root can be negative, check the argument before passing it to sqrt.
- Pass the Hamiltonian matrix to functions instead of allocating intermediate matrices.